### PR TITLE
Allow for duplicate ranges to be returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An implementation of the augmented interval tree algorithm in Ruby
 ### 2015-11-02, contribution by Carlos Alonso ( https://github.com/calonso )
 * Improved centering
 * Fixed searching: With some use cases with very large trees, the library fails to find intervals.
-* Added rubygems structure to be able to be pushed as a gem  
+* Added rubygems structure to be able to be pushed as a gem
 
 ### 2013-04-06, contribution by Simeon Simeonov ( https://github.com/ssimeonov )
 * **Range factory**: The current design allows for Range-compatible elements to be added except for the case where `Tree#ensure_exclusive_end` constructs a Range in a private method. In keeping with good design practices of containers such as Hash, this pull requests allows for a custom range factory to be provided to `Tree#initialize` while maintaining perfect backward compatibility.
@@ -29,9 +29,10 @@ See spec/interval_tree_spec.rb for details.
 ```ruby
 require "interval_tree"
 
-itv = [(0...3), (1...4), (3...5),]
+itv = [(0...3), (1...4), (3...5), (0...3)]
 t = IntervalTree::Tree.new(itv)
 p t.search(2)     #=> [0...3, 1...4]
+p t.search(2, unique: false) #=> [0...3, 1...4, 0...3]
 p t.search(1...4) #=> [0...3, 1...4, 3...5]
 ```
 
@@ -46,7 +47,7 @@ converted to half-closed intervals.
 # Copyright
 **Author**: MISHIMA, Hiroyuki ( https://github.com/misshie ),  Simeon Simeonov ( https://github.com/ssimeonov ), Carlos Alonso ( https://github.com/calonso ).
 
-**Copyright**: (c) 2011-2015 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonso  
+**Copyright**: (c) 2011-2015 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonso
 
 **License**: The MIT/X11 license
 

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -52,8 +52,10 @@ module IntervalTree
                divide_intervals(s_left), divide_intervals(s_right))
     end
 
+    DEFAULT_OPTIONS = {unique: true}
+    def search(interval, options = {})
+      options = DEFAULT_OPTIONS.merge(options)
 
-    def search(interval)
       return nil unless @top_node
       if interval.respond_to?(:first)
         first = interval.first
@@ -71,7 +73,7 @@ module IntervalTree
         end
         result.sort_by{|x|[x.first, x.last]}
       else
-        point_search(self.top_node, first, []).sort_by{|x|[x.first, x.last]}
+        point_search(self.top_node, first, [], options[:unique]).sort_by{|x|[x.first, x.last]}
       end
     end
 
@@ -97,7 +99,7 @@ module IntervalTree
       i.first + (i.last - i.first) / 2
     end
 
-    def point_search(node, point, result)
+    def point_search(node, point, result, unique = true)
       node.s_center.each do |k|
         if k.include?(point)
           result << k
@@ -109,7 +111,11 @@ module IntervalTree
       if node.right_node && ( point >= node.x_center )
         point_search(node.right_node, point, []).each{|k|result << k}
       end
-      result.uniq
+      if unique
+        result.uniq
+      else
+        result
+      end
     end
   end # class Tree
 

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -163,6 +163,22 @@ describe "IntervalTree::Tree" do
         expect(results).to be == [(3...5), (3...9), (4...8)]
       end
     end
+
+    context 'with unique: false' do
+      context 'given [(1...3), (1...3), (2...4), (1...3)]' do
+        it 'returns [(1...3), (1...3), (1...3)]' do
+          itvs = [(1...3), (1...3), (2...4), (1...3)]
+          results = IntervalTree::Tree.new(itvs).search(1, unique: false)
+          expect(results).to match_array([(1...3), (1...3), (1...3)])
+        end
+
+        it 'returns [(2..4)]' do
+          itvs = [(1...3), (1...3), (2...4), (1...3)]
+          results = IntervalTree::Tree.new(itvs).search(3, unique: false)
+          expect(results).to match_array([(2...4)])
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
User can specify an option in search `unique: false` if he wants multiple matches to be returned.