### PR TITLE
Improves search performance when search query is a large range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,41 @@
-# IntervalTree vesion 0.1.1
+# IntervalTree
+
 An implementation of the augmented interval tree algorithm in Ruby
 
-# See also
+## See also
+
 * description in Wikipedia http://en.wikipedia.org/wiki/Interval_tree
 * an implementation in Python by Tyler Kahn http://forrst.com/posts/Interval_Tree_implementation_in_python-e0K (broken link)
 
-# ChanegLog
+## ChangeLog
 
 ### 2017-05-12, contribution by Sam Davies ( https://github.com/samphilipd )
-* User can specify an option in search `unique: false` if s/he wants multiple matches to be returened.
+
+* User can specify an option in search `unique: false` if s/he wants multiple matches to be returned.
 
 ### 2015-11-02, contribution by Carlos Alonso ( https://github.com/calonso )
+
 * Improved centering
 * Fixed searching: With some use cases with very large trees, the library fails to find intervals.
 * Added rubygems structure to be able to be pushed as a gem
 
 ### 2013-04-06, contribution by Simeon Simeonov ( https://github.com/ssimeonov )
+
 * **Range factory**: The current design allows for Range-compatible elements to be added except for the case where `Tree#ensure_exclusive_end` constructs a Range in a private method. In keeping with good design practices of containers such as Hash, this pull requests allows for a custom range factory to be provided to `Tree#initialize` while maintaining perfect backward compatibility.
 Search in empty trees failing
 * Adds a nil guard in `Tree#search` to protect against empty tree searches failing.
 * **Cosmetic improvements**: Language & whitespace in specs, Gemfile addition, and .gitignore update
 
-# Install
+## Install
 
 ```bash
 $ gem install augmented_interval_tree
 ```
 
-# Usage
+## Usage
+
 See spec/interval_tree_spec.rb for details.
+
 ```ruby
 require "interval_tree"
 
@@ -39,7 +46,8 @@ p t.search(2, unique: false) #=> [0...3, 1...4, 0...3]
 p t.search(1...4) #=> [0...3, 1...4, 3...5]
 ```
 
-# Note
+## Note
+
 Result intervals are always returned
 in the "left-closed and right-open" style that can be expressed
 by three-dotted Range object literals `(first...last)`
@@ -47,7 +55,8 @@ by three-dotted Range object literals `(first...last)`
 Two-dotted full-closed intervals `(first..last)` are also accepted and internally
 converted to half-closed intervals.
 
-# Copyright
+## Copyright
+
 **Author**: MISHIMA, Hiroyuki ( https://github.com/misshie ),  Simeon Simeonov ( https://github.com/ssimeonov ), Carlos Alonso ( https://github.com/calonso ), Sam Davies ( https://github.com/samphilipd ).
 
 **Copyright**: (c) 2011-2017 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonsol; Sam Davies

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ An implementation of the centered interval tree algorithm in Ruby.
 
 ## ChangeLog
 
+### 2020-11-09, contribution by Brendan Weibrecht, Chris Nankervis and Thomas van der Pol
+
+* Substantially improved performance when supplied with a large range as the search query.
+
 ### 2017-05-12, contribution by Sam Davies ( https://github.com/samphilipd )
 
 * User can specify an option in search `unique: false` if s/he wants multiple matches to be returned.
@@ -57,8 +61,8 @@ converted to half-closed intervals.
 
 ## Copyright
 
-**Author**: MISHIMA, Hiroyuki ( https://github.com/misshie ),  Simeon Simeonov ( https://github.com/ssimeonov ), Carlos Alonso ( https://github.com/calonso ), Sam Davies ( https://github.com/samphilipd ).
+**Author**: MISHIMA, Hiroyuki ( https://github.com/misshie ),  Simeon Simeonov ( https://github.com/ssimeonov ), Carlos Alonso ( https://github.com/calonso ), Sam Davies ( https://github.com/samphilipd ), Brendan Weibrecht (https://github.com/ZimbiX), Chris Nankervis (https://github.com/chrisnankervis), Thomas van der Pol (https://github.com/tvanderpol).
 
-**Copyright**: (c) 2011-2017 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonsol; Sam Davies
+**Copyright**: (c) 2011-2020 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonsol; Sam Davies; Brendan Weibrecht; Chris Nankervis; Thomas van der Pol
 
 **License**: The MIT/X11 license

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IntervalTree
 
-An implementation of the augmented interval tree algorithm in Ruby
+An implementation of the centered interval tree algorithm in Ruby.
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ require "interval_tree"
 itv = [(0...3), (1...4), (3...5), (0...3)]
 t = IntervalTree::Tree.new(itv)
 p t.search(2)     #=> [0...3, 1...4]
-p t.search(2, unique: false) #=> [0...3, 1...4, 0...3]
+p t.search(2, unique: false) #=> [0...3, 0...3, 1...4]
 p t.search(1...4) #=> [0...3, 1...4, 3...5]
 ```
 

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -77,6 +77,10 @@ module IntervalTree
       end
     end
 
+    def ==(other)
+      top_node == other.top_node
+    end
+
     private
 
     def ensure_exclusive_end(ranges, range_factory)
@@ -128,6 +132,13 @@ module IntervalTree
       @right_node = right_node
     end
     attr_reader :x_center, :s_center, :left_node, :right_node
+
+    def ==(other)
+      x_center == other.x_center &&
+      s_center == other.s_center &&
+      left_node == other.left_node &&
+      right_node == other.right_node
+    end
   end # class Node
 
 end # module IntervalTree

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -39,10 +39,12 @@ module IntervalTree
       return nil unless @top_node
 
       if query.respond_to?(:first)
-        top_node.search(query)
+        result = top_node.search(query)
+        options[:unique] ? result.uniq : result
       else
-        point_search(self.top_node, query, [], options[:unique]).sort_by{|x|[x.first, x.last]}
+        point_search(self.top_node, query, [], options[:unique])
       end
+        .sort_by{|x|[x.first, x.last]}
     end
 
     def ==(other)

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -112,8 +112,8 @@ module IntervalTree
     # Search by range only
     def search(query)
       search_s_center(query) +
-        (query.begin.to_r < x_center && left_node&.search(query) || []) +
-        (query.end.to_r > x_center && right_node&.search(query) || [])
+        (left_node && query.begin.to_r < x_center && left_node.search(query) || []) +
+        (right_node && query.end.to_r > x_center && right_node.search(query) || [])
     end
 
     private

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -19,9 +19,9 @@ module IntervalTree
 
       intervals.each do |k|
         case
-        when k.last < x_center
+        when k.last.to_r < x_center
           s_left << k
-        when k.first > x_center
+        when k.first.to_r > x_center
           s_right << k
         else
           s_center << k
@@ -66,11 +66,10 @@ module IntervalTree
       end
     end
 
-    # Note: Floors the result
     def center(intervals)
       (
-        intervals.map(&:begin).min +
-        intervals.map(&:end).max
+        intervals.map(&:begin).min.to_r +
+        intervals.map(&:end).max.to_r
       ) / 2
     end
 
@@ -80,10 +79,10 @@ module IntervalTree
           result << k
         end
       end
-      if node.left_node && ( point < node.x_center )
+      if node.left_node && ( point.to_r < node.x_center )
         point_search(node.left_node, point, []).each{|k|result << k}
       end
-      if node.right_node && ( point >= node.x_center )
+      if node.right_node && ( point.to_r >= node.x_center )
         point_search(node.right_node, point, []).each{|k|result << k}
       end
       if unique
@@ -113,8 +112,8 @@ module IntervalTree
     # Search by range only
     def search(query)
       search_s_center(query) +
-        (query.begin < x_center && left_node&.search(query) || []) +
-        (query.end > x_center && right_node&.search(query) || [])
+        (query.begin.to_r < x_center && left_node&.search(query) || []) +
+        (query.end.to_r > x_center && right_node&.search(query) || [])
     end
 
     private

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -52,28 +52,17 @@ module IntervalTree
                divide_intervals(s_left), divide_intervals(s_right))
     end
 
+    # Search by range or point
     DEFAULT_OPTIONS = {unique: true}
-    def search(interval, options = {})
+    def search(query, options = {})
       options = DEFAULT_OPTIONS.merge(options)
 
       return nil unless @top_node
-      if interval.respond_to?(:first)
-        first = interval.first
-        last = interval.last
-      else
-        first = interval
-        last = nil
-      end
 
-      if last
-        result = Array.new
-        (first...last).each do |j|
-          search(j).each{|k|result << k}
-          result.uniq!
-        end
-        result.sort_by{|x|[x.first, x.last]}
+      if query.respond_to?(:first)
+        top_node.search(query)
       else
-        point_search(self.top_node, first, [], options[:unique]).sort_by{|x|[x.first, x.last]}
+        point_search(self.top_node, query, [], options[:unique]).sort_by{|x|[x.first, x.last]}
       end
     end
 
@@ -140,10 +129,11 @@ module IntervalTree
       right_node == other.right_node
     end
 
+    # Search by range only
     def search(query)
       search_s_center(query) +
-        (query.begin <= x_center && left_node&.search(query) || []) +
-        (query.end >= x_center && right_node&.search(query) || [])
+        (query.begin < x_center && left_node&.search(query) || []) +
+        (query.end > x_center && right_node&.search(query) || [])
     end
 
     private

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -139,6 +139,36 @@ module IntervalTree
       left_node == other.left_node &&
       right_node == other.right_node
     end
+
+    def search(query)
+      search_s_center(query) +
+        (query.begin <= x_center && left_node&.search(query) || []) +
+        (query.end >= x_center && right_node&.search(query) || [])
+    end
+
+    private
+
+    def search_s_center(query)
+      s_center.select do |k|
+        (
+          # k is entirely contained within the query
+          (k.begin >= query.begin) &&
+          (k.end <= query.end)
+        ) || (
+          # k's start overlaps with the query
+          (k.begin >= query.begin) &&
+          (k.begin < query.end)
+        ) || (
+          # k's end overlaps with the query
+          (k.end > query.begin) &&
+          (k.end <= query.end)
+        ) || (
+          # k is bigger than the query
+          (k.begin < query.begin) &&
+          (k.end > query.end)
+        )
+      end
+    end
   end # class Node
 
 end # module IntervalTree

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -92,11 +92,12 @@ module IntervalTree
       end
     end
 
-    # augmented tree
-    # using a start point as resresentative value of the node
+    # Note: Floors the result
     def center(intervals)
-      i = intervals.reduce([intervals.first.first, intervals.first.last]) { |acc, int| [[acc.first, int.first].min, [acc.last, int.last].max] }
-      i.first + (i.last - i.first) / 2
+      (
+        intervals.map(&:begin).min +
+        intervals.map(&:end).max
+      ) / 2
     end
 
     def point_search(node, point, result, unique = true)

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -1,25 +1,4 @@
 #!/usr/bin/env ruby
-#
-# Title:: the IntervalTree module using "augmented tree"
-# Author::   Hiroyuki Mishima, Simeon Simeonov, Carlos Alonso, Sam Davies
-# Copyright:: The MIT/X11 license
-#
-# see also ....
-#  description in Wikipedia
-#    http://en.wikipedia.org/wiki/Interval_tree
-#  implementation in Python by Tyler Kahn
-#    http://forrst.com/posts/Interval_Tree_implementation_in_python-e0K
-#
-# Usage:
-#  require "interval_tree"
-#  itv = [(0...3), (1...4), (3...5),]
-#  t = IntervalTree::Tree.new(itv)
-#  p t.search(2) => [0...3, 1...4]
-#  p t.search(1...3) => [0...3, 1...4, 3...5]
-#
-# note: result intervals are always returned
-# in the "left-closed and right-open" style that can be expressed
-# by three-dotted Range object literals (first...last)
 
 module IntervalTree
 

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe "IntervalTree::Node" do
-
   describe '.new' do
     context 'given ([], [], [], [])' do
       it 'returns a Node object' do
@@ -9,11 +8,9 @@ describe "IntervalTree::Node" do
       end
     end
   end
-
 end
 
 describe "IntervalTree::Tree" do
-
   describe '#center' do
     context 'given [(1...5),]' do
       it 'returns 3' do
@@ -72,6 +69,75 @@ describe "IntervalTree::Tree" do
           result = tree.search(2).first
           expect(result).to be_kind_of ValueRange
           expect(result.value).to be == 15
+        end
+      end
+    end
+
+    describe 'dividing intervals' do
+      subject(:tree) do
+        IntervalTree::Tree.new(
+          [
+            10...14,
+            2...20,
+            0...5,
+            0...8,
+            3...6,
+            15...20,
+            16...21,
+            17...25,
+            21...24,
+          ],
+        )
+      end
+
+      let(:node) do
+        IntervalTree::Node.new(
+          12, # x_center
+          [ 10...14, 2...20 ], # s_center
+          left_node, # s_left
+          right_node, # s_right
+        )
+      end
+      let(:left_node) do
+        IntervalTree::Node.new(
+          4, # x_center
+          [ 0...5, 0...8, 3...6 ], # s_center
+          nil, # s_left
+          nil, # s_right
+        )
+      end
+      let(:right_node) do
+        IntervalTree::Node.new(
+          20, # x_center
+          [ 15...20, 16...21, 17...25 ], # s_center
+          nil, # s_left
+          right_node_of_right_node, # s_right
+        )
+      end
+      let(:right_node_of_right_node) do
+        IntervalTree::Node.new(
+          22, # x_center
+          [ 21...24 ], # s_center
+          nil, # s_left
+          nil, # s_right
+        )
+      end
+
+      context 'given a set of intervals' do
+        it 'divides everything correctly' do
+          expect(tree.top_node).to eq(node)
+        end
+
+        it 'divides into a left node correctly' do
+          expect(tree.top_node.left_node).to eq(left_node)
+        end
+
+        it 'divides into a right node correctly' do
+          expect(tree.top_node.right_node).to eq(right_node)
+        end
+
+        it 'divides the right node into a right node correctly' do
+          expect(tree.top_node.right_node.right_node).to eq(right_node_of_right_node)
         end
       end
     end
@@ -172,7 +238,7 @@ describe "IntervalTree::Tree" do
           expect(results).to match_array([(1...3), (1...3), (1...3)])
         end
       end
-      
+
       context 'given [(1...3), (1...3), (2...4), (1...3)] and a query by (3)' do
         it 'returns [(2..4)]' do
           itvs = [(1...3), (1...3), (2...4), (1...3)]
@@ -182,5 +248,4 @@ describe "IntervalTree::Tree" do
       end
     end
   end
-  
 end

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -8,6 +8,52 @@ describe "IntervalTree::Node" do
       end
     end
   end
+
+  describe '#search' do
+    subject(:result) { node.search(-5...3) }
+
+    let(:node) do
+      IntervalTree::Tree.new(
+        [
+          10...14,
+          2...20,
+          0...5,
+          0...8,
+          3...6,
+          15...20,
+          16...21,
+          17...25,
+          21...24,
+        ],
+      ).top_node
+    end
+
+    before do
+      allow(node.left_node).to receive(:search).and_call_original
+      allow(node.right_node).to receive(:search).and_call_original
+      result
+    end
+
+    it 'returns the matching ranges' do
+      expect(result).to eq(
+        [
+          2...20,
+          0...5,
+          0...8,
+        ]
+      )
+    end
+
+    context 'only searches the necessary nodes' do
+      it 'searches the left node' do
+        expect(node.left_node).to have_received(:search)
+      end
+
+      it "does not search the right node, since the top node's center (12) is greater than the search's end (3)" do
+        expect(node.right_node).not_to have_received(:search)
+      end
+    end
+  end
 end
 
 describe "IntervalTree::Tree" do

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -276,6 +276,17 @@ describe "IntervalTree::Tree" do
       end
     end
 
+    context 'with unique defaulting to true' do
+      context 'given intervals with duplicates' do
+        it 'returns the duplicates in the result' do
+          itv = [(0...3), (1...4), (3...5), (0...3)]
+          t = IntervalTree::Tree.new(itv)
+          results = t.search(2)
+          expect(results).to match_array([0...3, 1...4])
+        end
+      end
+    end
+
     context 'with unique: false' do
       context 'given [(1...3), (1...3), (2...4), (1...3)] and a query by (1)' do
         it 'returns [(1...3), (1...3), (1...3)]' do

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -293,5 +293,20 @@ describe "IntervalTree::Tree" do
         end
       end
     end
+
+    context "when concerned with performance" do
+      context "with a small search space of very large ranges" do
+        it "should still be fast" do
+          itvs = [1...10_000_000]
+          needle = 5_000_001...15_000_000
+
+          a = Time.now
+          results = IntervalTree::Tree.new(itvs).search(needle)
+          b = Time.now
+
+          expect(b - a).to be_within(0.05).of(0)
+        end
+      end
+    end
   end
 end

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -62,7 +62,7 @@ describe "IntervalTree::Tree" do
       it 'returns 3' do
         itvs = [(1...5),]
         t = IntervalTree::Tree.new([])
-        expect(t.__send__(:center, itvs)).to be == 3
+        expect(t.__send__(:center, itvs)).to be == 3.0
 
       end
     end
@@ -71,7 +71,7 @@ describe "IntervalTree::Tree" do
       it 'returns 3' do
         itvs = [(1...5), (2...6),]
         t = IntervalTree::Tree.new([])
-        expect(t.__send__(:center, itvs)).to be == 3
+        expect(t.__send__(:center, itvs)).to be == 3.5
       end
     end
   end
@@ -88,7 +88,7 @@ describe "IntervalTree::Tree" do
       it 'returns ret.top_node.x_centeran == 4' do
         itvs = [(1...5), (2...6), (3...7)]
         tree = IntervalTree::Tree.new(itvs)
-        expect(tree.top_node.x_center).to be == 4
+        expect(tree.top_node.x_center).to be == 4.0
       end
     end
 
@@ -96,7 +96,7 @@ describe "IntervalTree::Tree" do
       it 'returns ret.top_node.x_centeran == 4 ' do
         itvs = [(1..5), (2..6), (3..7)]
         tree = IntervalTree::Tree.new(itvs)
-        expect(tree.top_node.x_center).to be == 4
+        expect(tree.top_node.x_center).to be == 4.5
       end
     end
 
@@ -138,7 +138,7 @@ describe "IntervalTree::Tree" do
 
       let(:node) do
         IntervalTree::Node.new(
-          12, # x_center
+          12.5, # x_center
           [ 10...14, 2...20 ], # s_center
           left_node, # s_left
           right_node, # s_right
@@ -162,7 +162,7 @@ describe "IntervalTree::Tree" do
       end
       let(:right_node_of_right_node) do
         IntervalTree::Node.new(
-          22, # x_center
+          22.5, # x_center
           [ 21...24 ], # s_center
           nil, # s_left
           nil, # s_right
@@ -317,6 +317,15 @@ describe "IntervalTree::Tree" do
 
           expect(b - a).to be_within(0.05).of(0)
         end
+      end
+    end
+
+    context 'when using time ranges' do
+      it 'still works' do
+        itvs = [Time.utc(2020, 11, 1)...Time.utc(2020, 11, 20)]
+        needle = Time.utc(2020, 11, 5)...Time.utc(2020, 11, 6)
+        results = IntervalTree::Tree.new(itvs).search(needle)
+        expect(results).to eq(itvs)
       end
     end
   end


### PR DESCRIPTION
For context, we have been implementing intersection in [the multi_range gem](https://github.com/khiav223577/multi_range/issues/18). We could have gone with nested iterated loops over the list of ranges but the time that'd take very quickly becomes unmanageable. Instead, we found this handy gem to let us use interval trees to avoid the naive iteration cost. 

However, the performance of this gem as implemented is not usable for large ranges - we have improved it in this PR. We plan to release a fork gem for our use for the moment but figured we'd contribute upstream.

For reference, here's the test case we first found that indicated the problem:

```
[3] pry(main)> a = Time.now; results = IntervalTree::Tree.new([1...10_000_000]).search(5_000_001...15_000_000); b = Time.now; puts "%0.6f seconds taken" % (b - a)
=> 20.191626 seconds taken
```

Here's the performance with our suggested changes:

```
[3] pry(main)> a = Time.now; results = IntervalTree::Tree.new([1...10_000_000]).search(5_000_001...15_000_000); b = Time.now; puts "%0.6f seconds taken" % (b - a)
=> 0.000023 seconds taken
```