### PR TITLE
Allow use with simple custom objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,44 @@ p t.search(2, unique: false) #=> [0...3, 0...3, 1...4]
 p t.search(1...4) #=> [0...3, 1...4, 3...5]
 ```
 
+Non-range objects can be used with the tree, as long as they respond to `begin` and `end`. This is useful for storing data along side the intervals. For example:
+```ruby
+require "interval_tree"
+
+CS = Struct.new(:begin, :end, :value) # CS = CustomStruct
+
+itv = [
+  CS.new(0,3, "Value"), CS.new(0,3, "Value"),
+  CS.new(1,4, %w[This is an array]), CS.new(3,5, %w[A second an array])
+]
+
+t = IntervalTree::Tree.new(itv)
+pp t.search(2)     
+#=> [#<struct CS begin=0, end=3, value="Value">,
+#    #<struct CS begin=1, end=4, value=["This", "is", "an", "array"]>]
+
+pp t.search(2, unique: false) 
+#=> [#<struct CS begin=0, end=3, value="Value">,
+#    #<struct CS begin=0, end=3, value="Value">, 
+#    #<struct CS begin=1, end=4, value=["This", "is", "an", "array"]>]
+
+pp t.search(1...4) 
+#=> [#<struct CS begin=0, end=3, value="Value">,
+#    #<struct CS begin=1, end=4, value=["This", "is", "an", "array"]>,
+#    #<struct CS begin=3, end=5, value=["A", "second", "an", "array"]>]
+```
+
 ## Note
 
 Result intervals are always returned
 in the "left-closed and right-open" style that can be expressed
-by three-dotted Range object literals `(first...last)`
+by three-dotted Range object literals `(begin...end)`
 
-Two-dotted full-closed intervals `(first..last)` are also accepted and internally
+Two-dotted full-closed intervals `(begin..end)` are also accepted and internally
 converted to half-closed intervals.
+
+When using custom objects the tree assumes the "left-closed and right-open" style (i.e. the `end` property is not
+considered to be inside the interval).
 
 ## Copyright
 

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -19,9 +19,9 @@ module IntervalTree
 
       intervals.each do |k|
         case
-        when k.last.to_r < x_center
+        when k.end.to_r < x_center
           s_left << k
-        when k.first.to_r > x_center
+        when k.begin.to_r > x_center
           s_right << k
         else
           s_center << k
@@ -38,13 +38,13 @@ module IntervalTree
 
       return nil unless @top_node
 
-      if query.respond_to?(:first)
+      if query.respond_to?(:begin)
         result = top_node.search(query)
         options[:unique] ? result.uniq : result
       else
         point_search(self.top_node, query, [], options[:unique])
       end
-        .sort_by{|x|[x.first, x.last]}
+        .sort_by{|x|[x.begin, x.end]}
     end
 
     def ==(other)
@@ -61,7 +61,7 @@ module IntervalTree
         when range.exclude_end?
           range
         else
-          range_factory.call(range.first, range.end)
+          range_factory.call(range.begin, range.end)
         end
       end
     end

--- a/lib/interval_tree.rb
+++ b/lib/interval_tree.rb
@@ -75,7 +75,7 @@ module IntervalTree
 
     def point_search(node, point, result, unique = true)
       node.s_center.each do |k|
-        if k.include?(point)
+        if k.begin <= point && point < k.end
           result << k
         end
       end

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -100,6 +100,16 @@ describe "IntervalTree::Tree" do
       end
     end
 
+    context 'with custom objects' do
+      CustomStruct = Struct.new(:begin, :end, :value)
+      context 'given [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]' do
+        it 'does not raise an exception' do
+          itvs = [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]
+          expect {IntervalTree::Tree.new(itvs)}.not_to raise_exception
+        end
+      end
+    end
+
     context 'with a custom range factory' do
       class ValueRange < Range
         attr_accessor :value
@@ -326,6 +336,39 @@ describe "IntervalTree::Tree" do
         needle = Time.utc(2020, 11, 5)...Time.utc(2020, 11, 6)
         results = IntervalTree::Tree.new(itvs).search(needle)
         expect(results).to eq(itvs)
+      end
+    end
+
+    context 'when using custom objects' do
+      CustomStruct = Struct.new(:begin, :end, :value)
+      context 'given [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]' do
+        it 'can search by point' do
+          itvs = [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]
+          tree = IntervalTree::Tree.new(itvs)
+          result = tree.search(2)
+          expect(result).to be_kind_of Array
+          item = result.first
+          expect(item).to be_kind_of CustomStruct
+          expect(item.value).to be == "value one"
+        end
+
+        it 'can search by range' do
+          itvs = [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]
+          tree = IntervalTree::Tree.new(itvs)
+          result = tree.search(4...7)
+          expect(result).to be == itvs
+          result = tree.search(9...20)
+          expect(result).to be_kind_of Array
+          item = result.first
+          expect(item).to be == CustomStruct.new(5, 11, "value two")
+        end
+
+        it 'can search by the custom object' do
+          itvs = [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]
+          tree = IntervalTree::Tree.new(itvs)
+          result = tree.search(CustomStruct.new(4,7))
+          expect(result).to be == itvs
+        end
       end
     end
   end

--- a/spec/interval_tree_spec.rb
+++ b/spec/interval_tree_spec.rb
@@ -340,7 +340,10 @@ describe "IntervalTree::Tree" do
     end
 
     context 'when using custom objects' do
-      CustomStruct = Struct.new(:begin, :end, :value)
+      before do
+        stub_const('CustomStruct', Struct.new(:begin, :end, :value))
+      end
+
       context 'given [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]' do
         it 'can search by point' do
           itvs = [CustomStruct.new(1, 6, "value one"), CustomStruct.new(5, 11, "value two")]


### PR DESCRIPTION
This PR is includes the work needed to be able to use the interval tree with simple classes and structs, such as this:
```ruby
CS = Struct.new(:begin, :end, :value) # CS = CustomStruct
itv = [
  CS.new(0,3, "Value"), CS.new(0,3, "Value"),
  CS.new(1,4, %w[This is an array]), CS.new(3,5, %w[A second an array])
]
t = IntervalTree::Tree.new(itv)
pp t.search(2)     
#=> [#<struct CS begin=0, end=3, value="Value">,
#    #<struct CS begin=1, end=4, value=["This", "is", "an", "array"]>]
```

I made the following changes:

1. Use `begin` instead of `first`, and `end` instead of `last`

2. Change point_search such that it does not assume the interval
has the `include?` method. This allows for custom objects to
be used as intervals.

3. Add specs for the behavior of the tree with custom
interval objects. Specs include:
    * Tree creation
    * Searching for custom objects
    * Searching with custom objects

4. Update the readme to include examples with custom objects, and
update the notes to reflect how custom objects behave.